### PR TITLE
Added start-of-line and end-of-line (<<, >>) positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+## master
+
+- Added start-of-line (<<) and end-of-line (>>) position operators
+
 ## 0.4.0 - 2016-03-03
 
 - Added PEGjs based parser

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ int square(int x)
 "Hello, World! // not a comment";
 // ^ string.quoted.double
 //                  ^ string.quoted.double
+
+// EOF Check (root scope)
+// >> source.c
 ```
 
 Once you've defined your grammar test, you can simply plug into the Jasmine

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -4,7 +4,7 @@ import parse from './grammar';
 import { matchScopes } from './scope';
 
 
-export class Assertion {
+class Assertion {
   constructor(line, column, ...scopes) {
     this.line = line;
     this.column = column;
@@ -20,15 +20,7 @@ export class Assertion {
   }
 
   findToken(...tokens) {
-    let columnNumber = 1;
-
-    return tokens.filter((token) => {
-      const startColumnNumber = columnNumber;
-      const endColumnNumber = columnNumber + token.value.length;
-      columnNumber = endColumnNumber;
-
-      return startColumnNumber <= this.column && this.column < endColumnNumber;
-    }).shift();
+    return tokens.filter((token) => token.matches(this.column)).shift();
   }
 
   message() {
@@ -56,7 +48,17 @@ export class AssertionParser {
     const [positions, scopes] = parse.parse(expression);
 
     return [
-      positions.map((p) => leadingWhitespace.length + (p > 0 ? p + this.header.openToken.length : 1)),
+      positions.map((p) => {
+        if (p <= 0) {
+          // start/end line indicators
+          return p;
+        } else if (p === 1) {
+          // open token indicator
+          return p + leadingWhitespace.length;
+        }
+        // carat indicator (includes open token, but move back 1 col to start of character)
+        return p + leadingWhitespace.length + this.header.openToken.length - 1;
+      }),
       scopes,
     ];
   }

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -4,7 +4,7 @@ import parse from './grammar';
 import { matchScopes } from './scope';
 
 
-class Assertion {
+export class Assertion {
   constructor(line, column, ...scopes) {
     this.line = line;
     this.column = column;

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -41,22 +41,28 @@ module.exports = (function() {
         peg$c2 = " ",
         peg$c3 = { type: "literal", value: " ", description: "\" \"" },
         peg$c4 = function(spaces) { return spaces.join(''); },
-        peg$c5 = "<-",
-        peg$c6 = { type: "literal", value: "<-", description: "\"<-\"" },
-        peg$c7 = function() { return [col]; },
-        peg$c8 = "^",
-        peg$c9 = { type: "literal", value: "^", description: "\"^\"" },
-        peg$c10 = function(spaces, carat) { col = col + spaces.length + carat.length; return col; },
-        peg$c11 = /^[a-zA-Z_]/,
-        peg$c12 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
-        peg$c13 = /^[a-zA-Z0-9_\-]/,
-        peg$c14 = { type: "class", value: "[a-zA-Z0-9_-]", description: "[a-zA-Z0-9_-]" },
-        peg$c15 = function(firstChar, suffix) { return firstChar + suffix.join(''); },
-        peg$c16 = ".",
-        peg$c17 = { type: "literal", value: ".", description: "\".\"" },
-        peg$c18 = function(dot, id) { return dot + id; },
-        peg$c19 = function(prefix, suffix) { return prefix + suffix.join(''); },
-        peg$c20 = function(scope) { return scope; },
+        peg$c5 = "<<",
+        peg$c6 = { type: "literal", value: "<<", description: "\"<<\"" },
+        peg$c7 = function() { return [0]; },
+        peg$c8 = ">>",
+        peg$c9 = { type: "literal", value: ">>", description: "\">>\"" },
+        peg$c10 = function() { return [-1]; },
+        peg$c11 = "<-",
+        peg$c12 = { type: "literal", value: "<-", description: "\"<-\"" },
+        peg$c13 = function() { return [col]; },
+        peg$c14 = "^",
+        peg$c15 = { type: "literal", value: "^", description: "\"^\"" },
+        peg$c16 = function(spaces, carat) { col = col + spaces.length + carat.length; return col; },
+        peg$c17 = /^[a-zA-Z_]/,
+        peg$c18 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
+        peg$c19 = /^[a-zA-Z0-9_\-]/,
+        peg$c20 = { type: "class", value: "[a-zA-Z0-9_-]", description: "[a-zA-Z0-9_-]" },
+        peg$c21 = function(firstChar, suffix) { return firstChar + suffix.join(''); },
+        peg$c22 = ".",
+        peg$c23 = { type: "literal", value: ".", description: "\".\"" },
+        peg$c24 = function(dot, id) { return dot + id; },
+        peg$c25 = function(prefix, suffix) { return prefix + suffix.join(''); },
+        peg$c26 = function(scope) { return scope; },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -321,7 +327,7 @@ module.exports = (function() {
       return s0;
     }
 
-    function peg$parsestartTokenPosition() {
+    function peg$parsestartLinePosition() {
       var s0, s1;
 
       s0 = peg$currPos;
@@ -341,6 +347,46 @@ module.exports = (function() {
       return s0;
     }
 
+    function peg$parseendLinePosition() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 2) === peg$c8) {
+        s1 = peg$c8;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c10();
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
+    function peg$parseopenTokenPosition() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 2) === peg$c11) {
+        s1 = peg$c11;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c12); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c13();
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
     function peg$parsecaratPosition() {
       var s0, s1, s2;
 
@@ -348,15 +394,15 @@ module.exports = (function() {
       s1 = peg$parsespaces();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 94) {
-          s2 = peg$c8;
+          s2 = peg$c14;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c9); }
+          if (peg$silentFails === 0) { peg$fail(peg$c15); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c10(s1, s2);
+          s1 = peg$c16(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -373,17 +419,23 @@ module.exports = (function() {
     function peg$parsepositions() {
       var s0, s1;
 
-      s0 = peg$parsestartTokenPosition();
+      s0 = peg$parsestartLinePosition();
       if (s0 === peg$FAILED) {
-        s0 = [];
-        s1 = peg$parsecaratPosition();
-        if (s1 !== peg$FAILED) {
-          while (s1 !== peg$FAILED) {
-            s0.push(s1);
+        s0 = peg$parseendLinePosition();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseopenTokenPosition();
+          if (s0 === peg$FAILED) {
+            s0 = [];
             s1 = peg$parsecaratPosition();
+            if (s1 !== peg$FAILED) {
+              while (s1 !== peg$FAILED) {
+                s0.push(s1);
+                s1 = peg$parsecaratPosition();
+              }
+            } else {
+              s0 = peg$FAILED;
+            }
           }
-        } else {
-          s0 = peg$FAILED;
         }
       }
 
@@ -394,35 +446,35 @@ module.exports = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (peg$c11.test(input.charAt(peg$currPos))) {
+      if (peg$c17.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c12); }
+        if (peg$silentFails === 0) { peg$fail(peg$c18); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c13.test(input.charAt(peg$currPos))) {
+        if (peg$c19.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c14); }
+          if (peg$silentFails === 0) { peg$fail(peg$c20); }
         }
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c13.test(input.charAt(peg$currPos))) {
+          if (peg$c19.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c14); }
+            if (peg$silentFails === 0) { peg$fail(peg$c20); }
           }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c15(s1, s2);
+          s1 = peg$c21(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -441,17 +493,17 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c16;
+        s1 = peg$c22;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        if (peg$silentFails === 0) { peg$fail(peg$c23); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseidentifier();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c18(s1, s2);
+          s1 = peg$c24(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -479,7 +531,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c19(s1, s2);
+          s1 = peg$c25(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -502,7 +554,7 @@ module.exports = (function() {
         s2 = peg$parsescope();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c20(s2);
+          s1 = peg$c26(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -538,7 +590,7 @@ module.exports = (function() {
        * Column counter
        * @type {Number}
        */
-      var col = 0;
+      var col = 1;
 
 
     peg$result = peg$startRuleFunction();

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -12,28 +12,31 @@
    * Column counter
    * @type {Number}
    */
-  var col = 0;
+  var col = 1;
 }
 
 assertion = positions scopes
 
 _ = [ \t]*
-spaces = spaces:" "* { return spaces.join(''); }
-startTokenPosition = "<-" { return [col]; }
-caratPosition = spaces:spaces carat:"^" { col = col + spaces.length + carat.length; return col; }
+spaces            = spaces:" "* { return spaces.join(''); }
 
-positions =
-  startTokenPosition / caratPosition+
+startLinePosition = "<<" { return [0]; }
+endLinePosition   = ">>" { return [-1]; }
+openTokenPosition = "<-" { return [col]; }
+caratPosition     = spaces:spaces carat:"^" { col = col + spaces.length + carat.length; return col; }
 
+positions         =
+  startLinePosition / endLinePosition / openTokenPosition / caratPosition+
 
-identifier = firstChar:[a-zA-Z_] suffix:[a-zA-Z0-9_-]* { return firstChar + suffix.join(''); }
+identifier        =
+  firstChar:[a-zA-Z_] suffix:[a-zA-Z0-9_-]* { return firstChar + suffix.join(''); }
 
-scopeSuffix = 
+scopeSuffix       =
   dot:"." id:identifier { return dot + id; }
-scope =
+scope             =
   prefix:identifier suffix:scopeSuffix* { return prefix + suffix.join(''); }
 
-scopeWithSpace =
+scopeWithSpace    =
   _ scope:scope { return scope; }
 
 scopes =

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,12 +2,12 @@
 /* eslint-env jasmine */
 /* global atom */
 
-import { Assertion, AssertionParser } from './assertions';
+import { AssertionParser } from './assertions';
 import { lines } from './io';
 import { escapeSpecName } from './jasmine';
 import { parse } from './parser';
+import { segmentTokens } from './tokens';
 import { takeWhile } from './utils';
-
 
 const customMatchers = {
 
@@ -31,7 +31,7 @@ const customMatchers = {
 };
 
 
-export default function(filename, { testRootScopeAtEOF } = { testRootScopeAtEOF: true }) {
+export default function(filename) {
   describe(`AtomGrammarTest(${filename})`, () => {
     const parser = parse(lines(filename));
     const grammarTest = new AssertionParser(parser);
@@ -51,40 +51,24 @@ export default function(filename, { testRootScopeAtEOF } = { testRootScopeAtEOF:
 
       const sanitizedLine = escapeSpecName(lastLine.line);
       it(`should parse line ${lastLine.lineNumber}: ${sanitizedLine}`, () => {
-        let oldRuleStack = null;
+        let startRuleStack = null;
+        let endRuleStack = null;
 
         for (const line of grammarLines) {
-          const { tokens, ruleStack } = this.grammar.tokenizeLine(line.line, oldRuleStack, oldRuleStack === null);
+          startRuleStack = endRuleStack;
+          const { tokens, ruleStack } = this.grammar.tokenizeLine(line.line, endRuleStack, endRuleStack === null);
 
           lastTokens = tokens;
-          oldRuleStack = ruleStack;
+          endRuleStack = ruleStack;
         }
 
+        const segmentedTokens = segmentTokens(
+          lastTokens,
+          (startRuleStack || []).map((r) => r.scopeName),  // Starting scopes
+          endRuleStack.map((r) => r.scopeName)  // Ending scopes
+        );
         for (const assertion of lastLine.assertions) {
-          expect(lastTokens).toHaveValidGrammar(assertion);
-        }
-      });
-    }
-
-    function addRootScopeAssertion(grammarLines, rootScope) {
-      it('should end the file in the root scope', () => {
-        let lastLine = 0;
-        let oldRuleStack = null;
-
-        for (const line of grammarLines) {
-          const { _tokens, ruleStack } = this.grammar.tokenizeLine(line.line, oldRuleStack, oldRuleStack === null);
-
-          oldRuleStack = ruleStack;
-          lastLine = line.lineNumber;
-        }
-
-        if (oldRuleStack !== null) {
-          const assertion = new Assertion(lastLine, 1, rootScope);
-          const eofTokens = [{
-            value: '<EOF>',
-            scopes: oldRuleStack.map((r) => r.scopeName),
-          }];
-          expect(eofTokens).toHaveValidGrammar(assertion);
+          expect(segmentedTokens).toHaveValidGrammar(assertion);
         }
       });
     }
@@ -93,9 +77,6 @@ export default function(filename, { testRootScopeAtEOF } = { testRootScopeAtEOF:
     for (;;) {
       const grammarLines = Array.from(takeWhile(grammarIterator, (line) => line.assertions.length <= 0));
       if (grammarLines.length <= 0) {
-        if (testRootScopeAtEOF) {
-          addRootScopeAssertion(lineAccumulator, grammarTest.header.scope);
-        }
         break;
       }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,7 +2,7 @@
 /* eslint-env jasmine */
 /* global atom */
 
-import { AssertionParser } from './assertions';
+import { Assertion, AssertionParser } from './assertions';
 import { lines } from './io';
 import { escapeSpecName } from './jasmine';
 import { parse } from './parser';
@@ -31,7 +31,7 @@ const customMatchers = {
 };
 
 
-export default function(filename) {
+export default function(filename, { testRootScopeAtEOF } = { testRootScopeAtEOF: true }) {
   describe(`AtomGrammarTest(${filename})`, () => {
     const parser = parse(lines(filename));
     const grammarTest = new AssertionParser(parser);
@@ -66,10 +66,36 @@ export default function(filename) {
       });
     }
 
+    function addRootScopeAssertion(grammarLines, rootScope) {
+      it('should end the file in the root scope', () => {
+        let lastLine = 0;
+        let oldRuleStack = null;
+
+        for (const line of grammarLines) {
+          const { _tokens, ruleStack } = this.grammar.tokenizeLine(line.line, oldRuleStack, oldRuleStack === null);
+
+          oldRuleStack = ruleStack;
+          lastLine = line.lineNumber;
+        }
+
+        if (oldRuleStack !== null) {
+          const assertion = new Assertion(lastLine, 1, rootScope);
+          const eofTokens = [{
+            value: '<EOF>',
+            scopes: oldRuleStack.map((r) => r.scopeName),
+          }];
+          expect(eofTokens).toHaveValidGrammar(assertion);
+        }
+      });
+    }
+
     const grammarIterator = grammarTest[Symbol.iterator]();
     for (;;) {
       const grammarLines = Array.from(takeWhile(grammarIterator, (line) => line.assertions.length <= 0));
       if (grammarLines.length <= 0) {
+        if (testRootScopeAtEOF) {
+          addRootScopeAssertion(lineAccumulator, grammarTest.header.scope);
+        }
         break;
       }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,7 @@
 'use babel';
 /* eslint-env jasmine */
 /* global atom */
+/* eslint-disable prefer-arrow-callback */
 
 import { AssertionParser } from './assertions';
 import { lines } from './io';
@@ -32,17 +33,17 @@ const customMatchers = {
 
 
 export default function(filename) {
-  describe(`AtomGrammarTest(${filename})`, () => {
+  describe(`AtomGrammarTest(${filename})`, function() {
     const parser = parse(lines(filename));
     const grammarTest = new AssertionParser(parser);
     let lineAccumulator = [];
 
-    beforeEach(function() { this.addMatchers(customMatchers); }); // eslint-disable-line prefer-arrow-callback
-    beforeEach(() => {
+    beforeEach(function() { this.addMatchers(customMatchers); });
+    beforeEach(function() {
       this.grammar = atom.grammars.grammarForScopeName(grammarTest.header.scope);
     });
 
-    function addAssertions(grammarLines) {
+    function addAssertions(grammarLines, rootScope) {
       let lastTokens = [];
       const [lastLine] = grammarLines.slice(-1);
       if (!lastLine.assertions.length) {
@@ -50,9 +51,10 @@ export default function(filename) {
       }
 
       const sanitizedLine = escapeSpecName(lastLine.line);
-      it(`should parse line ${lastLine.lineNumber}: ${sanitizedLine}`, () => {
+      it(`should parse line ${lastLine.lineNumber}: ${sanitizedLine}`, function() {
         let startRuleStack = null;
         let endRuleStack = null;
+        const rootRuleStack = [{ scopeName: rootScope }];
 
         for (const line of grammarLines) {
           startRuleStack = endRuleStack;
@@ -64,7 +66,7 @@ export default function(filename) {
 
         const segmentedTokens = segmentTokens(
           lastTokens,
-          (startRuleStack || []).map((r) => r.scopeName),  // Starting scopes
+          (startRuleStack || rootRuleStack).map((r) => r.scopeName),  // Starting scopes
           endRuleStack.map((r) => r.scopeName)  // Ending scopes
         );
         for (const assertion of lastLine.assertions) {
@@ -81,7 +83,7 @@ export default function(filename) {
       }
 
       lineAccumulator = lineAccumulator.concat(grammarLines);
-      addAssertions(lineAccumulator);
+      addAssertions(lineAccumulator, grammarTest.header.scope);
     }
   });
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -7,6 +7,7 @@ import { AssertionParser } from './assertions';
 import { lines } from './io';
 import { escapeSpecName } from './jasmine';
 import { parse } from './parser';
+import { rulesToScopes } from './scope';
 import { segmentTokens } from './tokens';
 import { takeWhile } from './utils';
 
@@ -66,8 +67,8 @@ export default function(filename) {
 
         const segmentedTokens = segmentTokens(
           lastTokens,
-          (startRuleStack || rootRuleStack).map((r) => r.scopeName),  // Starting scopes
-          endRuleStack.map((r) => r.scopeName)  // Ending scopes
+          rulesToScopes(startRuleStack || rootRuleStack),  // Starting scopes
+          rulesToScopes(endRuleStack)  // Ending scopes
         );
         for (const assertion of lastLine.assertions) {
           expect(segmentedTokens).toHaveValidGrammar(assertion);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -25,3 +25,8 @@ export function parseScopes(scopes) {
   }
   return scopeList;
 }
+
+
+export function rulesToScopes(rules) {
+  return rules.map((r) => r.scopeName).filter((r) => !!r);
+}

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -1,0 +1,51 @@
+'use babel';
+
+
+class Token {
+  constructor(start, end, ...scopes) {
+    this.start = start;
+    this.end = end;
+    this.scopes = scopes;
+  }
+
+  matches(column) {
+    return this.start <= column && column < this.end;
+  }
+}
+
+
+export class StartLineToken {
+  constructor(...scopes) {
+    this.scopes = scopes;
+  }
+
+  matches(column) {
+    return column === 0;
+  }
+}
+
+
+export class EndLineToken {
+  constructor(...scopes) {
+    this.scopes = scopes;
+  }
+
+  matches(column) {
+    return column === -1;
+  }
+}
+
+
+export function segmentTokens(tokens, startScopes, endScopes) {
+  let columnNumber = 1;
+  return Array.prototype.concat.call(
+    [new StartLineToken(...startScopes)],
+    tokens.map((token) => {
+      const start = columnNumber;
+      columnNumber = columnNumber + token.value.length;
+      const end = columnNumber;
+      return new Token(start, end, ...token.scopes);
+    }),
+    [new EndLineToken(...endScopes)]
+  );
+}

--- a/spec/assertions-spec.js
+++ b/spec/assertions-spec.js
@@ -43,6 +43,60 @@ describe('Assertions', () => {
       expect(assertions.length).toEqual(3);
     });
 
+    it('should parse << assertions', () => {
+      const parser = parserFixture(
+        '#pragma once',
+        '// << punctuation.definition.directive meta.preprocessor.c'
+      );
+
+      const assertion = Array.from(parser)[0].assertions[0];
+      expect(assertion.scopes).toEqual([
+        'punctuation.definition.directive',
+        'meta.preprocessor.c',
+      ]);
+      expect(assertion.column).toEqual(0);
+    });
+
+    it('should parse << assertions with leading whitespace', () => {
+      const parser = parserFixture(
+        '#pragma once',
+        ' // << keyword.control.directive.pragma'
+      );
+
+      const assertion = Array.from(parser)[0].assertions[0];
+      expect(assertion.scopes).toEqual([
+        'keyword.control.directive.pragma',
+      ]);
+      expect(assertion.column).toEqual(0);
+    });
+
+    it('should parse >> assertions', () => {
+      const parser = parserFixture(
+        '#pragma once',
+        '// >> punctuation.definition.directive meta.preprocessor.c'
+      );
+
+      const assertion = Array.from(parser)[0].assertions[0];
+      expect(assertion.scopes).toEqual([
+        'punctuation.definition.directive',
+        'meta.preprocessor.c',
+      ]);
+      expect(assertion.column).toEqual(-1);
+    });
+
+    it('should parse >> assertions with leading whitespace', () => {
+      const parser = parserFixture(
+        '#pragma once',
+        ' // >> keyword.control.directive.pragma'
+      );
+
+      const assertion = Array.from(parser)[0].assertions[0];
+      expect(assertion.scopes).toEqual([
+        'keyword.control.directive.pragma',
+      ]);
+      expect(assertion.column).toEqual(-1);
+    });
+
     it('should parse <- assertions', () => {
       const parser = parserFixture(
         '#pragma once',

--- a/spec/fixtures/C/syntax_test_c_example.c
+++ b/spec/fixtures/C/syntax_test_c_example.c
@@ -28,3 +28,6 @@ int square(int x)
 "Hello, World! // not a comment";
 // ^ string.quoted.double
 //                  ^ string.quoted.double
+
+// EOF Check (root scope)
+// >> source.c

--- a/spec/fixtures/HTML/syntax_test_html_inline.html
+++ b/spec/fixtures/HTML/syntax_test_html_inline.html
@@ -1,0 +1,5 @@
+<!-- SYNTAX TEST "text.html.basic" -->
+<script> console.log('hi'); </script>
+<!-- << text.html.basic -->
+<!--    ^^^^^^^^^^^^^^^^^^^^ source.js.embedded.html -->
+<!-- >> text.html.basic -->

--- a/spec/fixtures/RootScope/syntax_test_complete_block.c
+++ b/spec/fixtures/RootScope/syntax_test_complete_block.c
@@ -1,0 +1,9 @@
+// SYNTAX TEST "source.c"
+int square(int x)
+// <- storage.type
+//  ^ meta.function entity.name.function
+//         ^ storage.type
+{
+    return x * x;
+}
+// The brace is closed

--- a/spec/fixtures/RootScope/syntax_test_incomplete_block.c
+++ b/spec/fixtures/RootScope/syntax_test_incomplete_block.c
@@ -1,0 +1,8 @@
+// SYNTAX TEST "source.c"
+int square(int x)
+// <- storage.type
+//  ^ meta.function entity.name.function
+//         ^ storage.type
+{
+    return x * x;
+// The brace is never closed

--- a/spec/grammar-spec.js
+++ b/spec/grammar-spec.js
@@ -30,30 +30,44 @@ describe('Grammar', () => {
     itShouldNotParse('<- ');
 
     describe('Positions', () => {
-      it('should parse start token operators', () => {
-        expect(parse.parse('<- something')).toEqual([
+      it('should parse start line operators', () => {
+        expect(parse.parse('<< something')).toEqual([
           [0],
+          ['something'],
+        ]);
+      });
+
+      it('should parse end line operators', () => {
+        expect(parse.parse('>> something')).toEqual([
+          [-1],
+          ['something'],
+        ]);
+      });
+
+      it('should parse open token operators', () => {
+        expect(parse.parse('<- something')).toEqual([
+          [1],
           ['something'],
         ]);
       });
 
       it('should parse carat operators', () => {
         expect(parse.parse('    ^ something')).toEqual([
-          [5],
+          [6],
           ['something'],
         ]);
       });
 
       it('should parse multiple carat operators', () => {
         expect(parse.parse(' ^  ^ something')).toEqual([
-          [2, 5],
+          [3, 6],
           ['something'],
         ]);
       });
 
       it('should parse consecutive carat operators', () => {
         expect(parse.parse(' ^^^^ something')).toEqual([
-          [2, 3, 4, 5],
+          [3, 4, 5, 6],
           ['something'],
         ]);
       });
@@ -62,28 +76,28 @@ describe('Grammar', () => {
     describe('Scopes', () => {
       it('should parse single part scope', () => {
         expect(parse.parse('<- something')).toEqual([
-          [0],
+          [1],
           ['something'],
         ]);
       });
 
       it('should parse a multipart scope', () => {
         expect(parse.parse('<- something.else')).toEqual([
-          [0],
+          [1],
           ['something.else'],
         ]);
       });
 
       it('should parse a multiple scopes', () => {
         expect(parse.parse('<- something else')).toEqual([
-          [0],
+          [1],
           ['something', 'else'],
         ]);
       });
 
       it('should parse a multipart scope with a dash', () => {
         expect(parse.parse('<- something.my-attr else')).toEqual([
-          [0],
+          [1],
           ['something.my-attr', 'else'],
         ]);
       });

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -15,5 +15,6 @@ describe('Atom Grammar Test Jasmine', () => {
   describe('HTML Syntax Assertions', () => {
     beforeEach(() => waitsForPromise(() => atom.packages.activatePackage('language-html')));
     grammarTest(fixtureFilename('HTML/syntax_test_html_example.html'));
+    grammarTest(fixtureFilename('HTML/syntax_test_html_inline.html'));
   });
 });


### PR DESCRIPTION
You can now match scopes at the beginning and end of the line.

```
<script> console.log('hi'); </script>
<!-- << text.html.basic -->
<!--    ^^^^^^^^^^^^^^^^^^^^ source.js.embedded.html -->
<!-- >> text.html.basic -->
```
