### PR TITLE
Added grouping and only: modifier for scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## master
 
 - Added start-of-line (<<) and end-of-line (>>) position operators
+- Added scope matching modifier and grouping (`only:` or `=`)
+  - =(scope1 scope2)
+  - only:scope1
+  - =scope1
 
 ## 0.4.0 - 2016-03-03
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ int square(int x)
 //                  ^ string.quoted.double
 
 // EOF Check (root scope)
-// >> source.c
+// >> =source.c
 ```
 
 Once you've defined your grammar test, you can simply plug into the Jasmine

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1,22 +1,14 @@
 'use babel';
 
 import parse from './grammar';
-import { matchScopes } from './scope';
+import { matcherBuilder } from './matchers';
 
 
 class Assertion {
-  constructor(line, column, ...scopes) {
+  constructor(line, column, matcher) {
     this.line = line;
     this.column = column;
-    this.scopes = scopes;
-  }
-
-  findMissing(...scopes) {
-    return this.scopes.filter((expected) =>
-      !scopes.some((actual) =>
-        matchScopes(actual, expected)
-      )
-    );
+    this.matcher = matcher;
   }
 
   findToken(...tokens) {
@@ -24,7 +16,7 @@ class Assertion {
   }
 
   message() {
-    return `${this.scopes.join(', ')} at ${this.line}:${this.column}`;
+    return `${this.matcher.scopes.join(', ')} at ${this.line}:${this.column}`;
   }
 }
 
@@ -68,14 +60,16 @@ export class AssertionParser {
 
     for (const value of this.iterator) {
       try {
-        const [positions, scopes] = this.parseLine(value.line);
+        const [positions, [modifier, scopes]] = this.parseLine(value.line);
         if (!currentLine) {
           throw Error("Can't have assertion before any syntax");
         }
 
+        const matcher = matcherBuilder(modifier, ...scopes);
+
         for (const position of positions) {
           currentLine.assertions.push(
-            new Assertion(currentLine.lineNumber, position, ...scopes)
+            new Assertion(currentLine.lineNumber, position, matcher)
           );
         }
       } catch (_e) {

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -58,11 +58,26 @@ module.exports = (function() {
         peg$c19 = /^[a-zA-Z0-9_\-]/,
         peg$c20 = { type: "class", value: "[a-zA-Z0-9_-]", description: "[a-zA-Z0-9_-]" },
         peg$c21 = function(firstChar, suffix) { return firstChar + suffix.join(''); },
-        peg$c22 = ".",
-        peg$c23 = { type: "literal", value: ".", description: "\".\"" },
-        peg$c24 = function(dot, id) { return dot + id; },
-        peg$c25 = function(prefix, suffix) { return prefix + suffix.join(''); },
-        peg$c26 = function(scope) { return scope; },
+        peg$c22 = "only:",
+        peg$c23 = { type: "literal", value: "only:", description: "\"only:\"" },
+        peg$c24 = "=",
+        peg$c25 = { type: "literal", value: "=", description: "\"=\"" },
+        peg$c26 = function() { return "="; },
+        peg$c27 = function(only) { return only },
+        peg$c28 = ".",
+        peg$c29 = { type: "literal", value: ".", description: "\".\"" },
+        peg$c30 = function(dot, id) { return dot + id; },
+        peg$c31 = function(prefix, suffix) { return prefix + suffix.join(''); },
+        peg$c32 = function(scope) { return scope; },
+        peg$c33 = function(scope) { return [scope]; },
+        peg$c34 = function(scope, scopes) { return Array.prototype.concat.call([scope], scopes); },
+        peg$c35 = "(",
+        peg$c36 = { type: "literal", value: "(", description: "\"(\"" },
+        peg$c37 = ")",
+        peg$c38 = { type: "literal", value: ")", description: "\")\"" },
+        peg$c39 = function(scopes) { return scopes; },
+        peg$c40 = function(modifier, scopes) { return [modifier, scopes] },
+        peg$c41 = function(scopes) { return ["@", scopes]; },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -488,22 +503,65 @@ module.exports = (function() {
       return s0;
     }
 
+    function peg$parseonly() {
+      var s0, s1;
+
+      if (input.substr(peg$currPos, 5) === peg$c22) {
+        s0 = peg$c22;
+        peg$currPos += 5;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c23); }
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 61) {
+          s1 = peg$c24;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
+        }
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c26();
+        }
+        s0 = s1;
+      }
+
+      return s0;
+    }
+
+    function peg$parsemodifier() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      s1 = peg$parseonly();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c27(s1);
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
     function peg$parsescopeSuffix() {
       var s0, s1, s2;
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c22;
+        s1 = peg$c28;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c23); }
+        if (peg$silentFails === 0) { peg$fail(peg$c29); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseidentifier();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c24(s1, s2);
+          s1 = peg$c30(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -531,7 +589,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c25(s1, s2);
+          s1 = peg$c31(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -554,7 +612,158 @@ module.exports = (function() {
         s2 = peg$parsescope();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c26(s2);
+          s1 = peg$c32(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsesingleScope() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      s1 = peg$parsescope();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c33(s1);
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
+    function peg$parsemultiScopes() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parsescope();
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        s3 = peg$parsescopeWithSpace();
+        if (s3 !== peg$FAILED) {
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$parsescopeWithSpace();
+          }
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c34(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsegroupedScopes() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 40) {
+        s1 = peg$c35;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c36); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsemultiScopes();
+        if (s2 === peg$FAILED) {
+          s2 = peg$parsesingleScope();
+        }
+        if (s2 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 41) {
+            s3 = peg$c37;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c38); }
+          }
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c39(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsemodifiedScopes() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parse_();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsemodifier();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsegroupedScopes();
+          if (s3 === peg$FAILED) {
+            s3 = peg$parsesingleScope();
+          }
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c40(s2, s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parseunmodifiedScopes() {
+      var s0, s1, s2;
+
+      s0 = peg$currPos;
+      s1 = peg$parse_();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsegroupedScopes();
+        if (s2 === peg$FAILED) {
+          s2 = peg$parsemultiScopes();
+          if (s2 === peg$FAILED) {
+            s2 = peg$parsesingleScope();
+          }
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c41(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -569,17 +778,11 @@ module.exports = (function() {
     }
 
     function peg$parsescopes() {
-      var s0, s1;
+      var s0;
 
-      s0 = [];
-      s1 = peg$parsescopeWithSpace();
-      if (s1 !== peg$FAILED) {
-        while (s1 !== peg$FAILED) {
-          s0.push(s1);
-          s1 = peg$parsescopeWithSpace();
-        }
-      } else {
-        s0 = peg$FAILED;
+      s0 = peg$parsemodifiedScopes();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseunmodifiedScopes();
       }
 
       return s0;

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -17,7 +17,7 @@
 
 assertion = positions scopes
 
-_ = [ \t]*
+_                 = [ \t]*
 spaces            = spaces:" "* { return spaces.join(''); }
 
 startLinePosition = "<<" { return [0]; }
@@ -31,13 +31,32 @@ positions         =
 identifier        =
   firstChar:[a-zA-Z_] suffix:[a-zA-Z0-9_-]* { return firstChar + suffix.join(''); }
 
+only              = "only:" / "=" { return "="; }
+modifier          = only:only { return only }
+
 scopeSuffix       =
   dot:"." id:identifier { return dot + id; }
+
 scope             =
   prefix:identifier suffix:scopeSuffix* { return prefix + suffix.join(''); }
 
 scopeWithSpace    =
   _ scope:scope { return scope; }
 
-scopes =
-  scopeWithSpace+
+singleScope       =
+  scope:scope { return [scope]; }
+
+multiScopes       =
+  scope:scope scopes:(scopeWithSpace)+ { return Array.prototype.concat.call([scope], scopes); }
+
+groupedScopes     =
+  "(" scopes:(multiScopes / singleScope) ")" { return scopes; }
+
+modifiedScopes    =
+  _ modifier:modifier scopes:(groupedScopes / singleScope) { return [modifier, scopes] }
+
+unmodifiedScopes  =
+  _ scopes:(groupedScopes / multiScopes / singleScope) { return ["@", scopes]; }
+
+scopes            =
+  modifiedScopes / unmodifiedScopes

--- a/lib/main.js
+++ b/lib/main.js
@@ -21,9 +21,7 @@ const customMatchers = {
       return false;
     }
 
-    const missing = assertion.findMissing(...token.scopes);
-
-    if (missing.length) {
+    if (!assertion.matcher.matches(...token.scopes)) {
       this.message = () => `Expected to find ${assertion.message()}, instead found ${token.scopes.join(', ')}`;
       return false;
     }

--- a/lib/matchers.js
+++ b/lib/matchers.js
@@ -1,0 +1,60 @@
+'use babel';
+
+import { matchScopes } from './scope';
+import { zipLongest } from './utils';
+
+
+class Matcher {
+  constructor(...scopes) {
+    this.scopes = scopes;
+  }
+
+  matches(..._scopes) {
+    throw Error('Not Implemented');
+  }
+
+  message() {
+    throw Error('Not Implemented');
+  }
+}
+
+
+export class Contains extends Matcher {
+  matches(...scopes) {
+    return this.scopes.every((expected) =>
+      scopes.some((actual) =>
+        matchScopes(actual, expected)
+      )
+    );
+  }
+
+  message() {
+    return this.scopes.join(', ');
+  }
+}
+
+
+export class Only extends Matcher {
+  matches(...scopes) {
+    const source = Array.from(this.scopes).sort();
+    const target = Array.from(scopes).sort();
+
+    return zipLongest(source, target).every((vals) => matchScopes(...vals));
+  }
+
+  message() {
+    return `only ${this.scopes.join(', ')}`;
+  }
+}
+
+
+export function matcherBuilder(modifier, ...scopes) {
+  switch (modifier) {
+    case '@':
+      return new Contains(...scopes);
+    case '=':
+      return new Only(...scopes);
+    default:
+      throw Error(`Unknown modifier: ${modifier}`);
+  }
+}

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -6,7 +6,7 @@ import { zip } from './utils';
 const SCOPE_REGEX = /\S+/gi;
 
 
-export function matchScopes(actual, expected) {
+export function matchScopes(actual = '', expected = '') {
   const actualArray = actual.split('.');
   const expectedArray = expected.split('.');
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,12 @@ export function zip(...arrays) {
 }
 
 
+export function zipLongest(...arrays) {
+  const longest = arrays.length <= 0 ? [] : arrays.reduce((a, b) => a.length > b.length ? a : b);
+  return longest.map((_, i) => arrays.map(a => a[i]));
+}
+
+
 export function* takeWhile(iterator, callback) {
   for (const item of iterator) {
     yield item;

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   "files": [
     "lib"
   ],
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
-    "pegjs": "^0.9.0",
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^6.0.2",
-    "eslint-plugin-react": "^4.1.0"
+    "eslint-plugin-react": "^4.1.0",
+    "jasmine-es6": "^0.1.6",
+    "pegjs": "^0.9.0"
   }
 }

--- a/spec/assertions-spec.js
+++ b/spec/assertions-spec.js
@@ -50,7 +50,7 @@ describe('Assertions', () => {
       );
 
       const assertion = Array.from(parser)[0].assertions[0];
-      expect(assertion.scopes).toEqual([
+      expect(assertion.matcher.scopes).toEqual([
         'punctuation.definition.directive',
         'meta.preprocessor.c',
       ]);
@@ -64,7 +64,7 @@ describe('Assertions', () => {
       );
 
       const assertion = Array.from(parser)[0].assertions[0];
-      expect(assertion.scopes).toEqual([
+      expect(assertion.matcher.scopes).toEqual([
         'keyword.control.directive.pragma',
       ]);
       expect(assertion.column).toEqual(0);
@@ -77,7 +77,7 @@ describe('Assertions', () => {
       );
 
       const assertion = Array.from(parser)[0].assertions[0];
-      expect(assertion.scopes).toEqual([
+      expect(assertion.matcher.scopes).toEqual([
         'punctuation.definition.directive',
         'meta.preprocessor.c',
       ]);
@@ -91,7 +91,7 @@ describe('Assertions', () => {
       );
 
       const assertion = Array.from(parser)[0].assertions[0];
-      expect(assertion.scopes).toEqual([
+      expect(assertion.matcher.scopes).toEqual([
         'keyword.control.directive.pragma',
       ]);
       expect(assertion.column).toEqual(-1);
@@ -104,7 +104,7 @@ describe('Assertions', () => {
       );
 
       const assertion = Array.from(parser)[0].assertions[0];
-      expect(assertion.scopes).toEqual([
+      expect(assertion.matcher.scopes).toEqual([
         'punctuation.definition.directive',
         'meta.preprocessor.c',
       ]);
@@ -118,7 +118,7 @@ describe('Assertions', () => {
       );
 
       const assertion = Array.from(parser)[0].assertions[0];
-      expect(assertion.scopes).toEqual([
+      expect(assertion.matcher.scopes).toEqual([
         'keyword.control.directive.pragma',
       ]);
       expect(assertion.column).toEqual(2);
@@ -131,7 +131,7 @@ describe('Assertions', () => {
       );
 
       const assertion = Array.from(parser)[0].assertions[0];
-      expect(assertion.scopes).toEqual([
+      expect(assertion.matcher.scopes).toEqual([
         'keyword.control.directive.pragma',
       ]);
       expect(assertion.column).toEqual(4);
@@ -144,7 +144,7 @@ describe('Assertions', () => {
       );
 
       const assertion = Array.from(parser)[0].assertions[0];
-      expect(assertion.scopes).toEqual([
+      expect(assertion.matcher.scopes).toEqual([
         'keyword.control.directive.pragma',
       ]);
       expect(assertion.column).toEqual(6);
@@ -157,7 +157,7 @@ describe('Assertions', () => {
       );
 
       const assertion = Array.from(parser)[0].assertions[0];
-      expect(assertion.scopes).toEqual([
+      expect(assertion.matcher.scopes).toEqual([
         'keyword.control.directive.pragma',
       ]);
       expect(assertion.column).toEqual(7);
@@ -170,7 +170,7 @@ describe('Assertions', () => {
       );
 
       const assertion = Array.from(parser)[0].assertions[0];
-      expect(assertion.scopes).toEqual([
+      expect(assertion.matcher.scopes).toEqual([
         'keyword.control.directive.pragma',
       ]);
       expect(assertion.column).toEqual(4);
@@ -185,12 +185,12 @@ describe('Assertions', () => {
       const assertions = Array.from(parser)[0].assertions;
       expect(assertions.length).toBe(2);
       const [assertion1, assertion2] = assertions;
-      expect(assertion1.scopes).toEqual([
+      expect(assertion1.matcher.scopes).toEqual([
         'some.symbol',
       ]);
       expect(assertion1.column).toEqual(4);
 
-      expect(assertion2.scopes).toEqual([
+      expect(assertion2.matcher.scopes).toEqual([
         'some.symbol',
       ]);
       expect(assertion2.column).toEqual(10);

--- a/spec/fixtures/HTML/syntax_test_html_inline.html
+++ b/spec/fixtures/HTML/syntax_test_html_inline.html
@@ -1,5 +1,5 @@
 <!-- SYNTAX TEST "text.html.basic" -->
 <script> console.log('hi'); </script>
-<!-- << text.html.basic -->
+<!-- << =text.html.basic -->
 <!--    ^^^^^^^^^^^^^^^^^^^^ source.js.embedded.html -->
-<!-- >> text.html.basic -->
+<!-- >> =text.html.basic -->

--- a/spec/grammar-spec.js
+++ b/spec/grammar-spec.js
@@ -23,52 +23,56 @@ describe('Grammar', () => {
     itShouldParse('    ^              ^   meta.brace.curly.js');
     itShouldParse('    ^ blah.blah');
     itShouldParse('    ^^^^    Something');
+    itShouldParse('<- =something');
+    itShouldParse('<- only:something');
 
     itShouldNotParse('');
     itShouldNotParse('nothing');
     itShouldNotParse('^ ');
     itShouldNotParse('<- ');
+    itShouldNotParse('<- =something else');
+    itShouldNotParse('<- only:something else');
 
     describe('Positions', () => {
       it('should parse start line operators', () => {
         expect(parse.parse('<< something')).toEqual([
           [0],
-          ['something'],
+          ['@', ['something']],
         ]);
       });
 
       it('should parse end line operators', () => {
         expect(parse.parse('>> something')).toEqual([
           [-1],
-          ['something'],
+          ['@', ['something']],
         ]);
       });
 
       it('should parse open token operators', () => {
         expect(parse.parse('<- something')).toEqual([
           [1],
-          ['something'],
+          ['@', ['something']],
         ]);
       });
 
       it('should parse carat operators', () => {
         expect(parse.parse('    ^ something')).toEqual([
           [6],
-          ['something'],
+          ['@', ['something']],
         ]);
       });
 
       it('should parse multiple carat operators', () => {
         expect(parse.parse(' ^  ^ something')).toEqual([
           [3, 6],
-          ['something'],
+          ['@', ['something']],
         ]);
       });
 
       it('should parse consecutive carat operators', () => {
         expect(parse.parse(' ^^^^ something')).toEqual([
           [3, 4, 5, 6],
-          ['something'],
+          ['@', ['something']],
         ]);
       });
     });
@@ -77,29 +81,64 @@ describe('Grammar', () => {
       it('should parse single part scope', () => {
         expect(parse.parse('<- something')).toEqual([
           [1],
-          ['something'],
+          ['@', ['something']],
+        ]);
+      });
+
+      it('should parse single part scope with a modifier', () => {
+        expect(parse.parse('<- =something')).toEqual([
+          [1],
+          ['=', ['something']],
         ]);
       });
 
       it('should parse a multipart scope', () => {
         expect(parse.parse('<- something.else')).toEqual([
           [1],
-          ['something.else'],
+          ['@', ['something.else']],
         ]);
       });
 
-      it('should parse a multiple scopes', () => {
+      it('should parse multiple scopes', () => {
         expect(parse.parse('<- something else')).toEqual([
           [1],
-          ['something', 'else'],
+          ['@', ['something', 'else']],
+        ]);
+      });
+
+
+      it('should parse grouped multiple scopes', () => {
+        expect(parse.parse('<- (something else.other)')).toEqual([
+          [1],
+          ['@', ['something', 'else.other']],
         ]);
       });
 
       it('should parse a multipart scope with a dash', () => {
         expect(parse.parse('<- something.my-attr else')).toEqual([
           [1],
-          ['something.my-attr', 'else'],
+          ['@', ['something.my-attr', 'else']],
         ]);
+      });
+
+      describe('Modifiers', () => {
+        it('should parse single part scope', () => {
+          expect(parse.parse('<- =something')).toEqual([
+            [1],
+            ['=', ['something']],
+          ]);
+        });
+
+        it('should parse grouped scope', () => {
+          expect(parse.parse('<- =(something else)')).toEqual([
+            [1],
+            ['=', ['something', 'else']],
+          ]);
+        });
+
+        it('should not parse ungrouped scope', () => {
+          expect(() => parse.parse('<- =something else')).toThrow();
+        });
       });
     });
   });

--- a/spec/matchers-spec.js
+++ b/spec/matchers-spec.js
@@ -1,0 +1,50 @@
+'use babel';
+
+import { Contains, Only } from '../lib/matchers';
+
+
+describe('Matchers', () => {
+  describe('Contains', () => {
+    it('should match equal single value', () => {
+      expect(new Contains('test').matches('test')).toBeTruthy();
+    });
+
+    it('should match equal multiple values', () => {
+      expect(new Contains('test', 'test2').matches('test', 'test2')).toBeTruthy();
+    });
+
+    it('should match equal multiple values out of order', () => {
+      expect(new Contains('test', 'test2').matches('test2', 'test')).toBeTruthy();
+    });
+
+    it('should match a single value against multiple values', () => {
+      expect(new Contains('test').matches('test', 'test2')).toBeTruthy();
+    });
+
+    it('should not match a different value against a single value', () => {
+      expect(new Contains('blah').matches('test')).toBeFalsy();
+    });
+
+    it('should not match a different value against multiple values', () => {
+      expect(new Contains('blah').matches('test', 'test2')).toBeFalsy();
+    });
+  });
+
+  describe('Only', () => {
+    it('should match equal single value', () => {
+      expect(new Only('test').matches('test')).toBeTruthy();
+    });
+
+    it('should match equal multiple values', () => {
+      expect(new Only('test', 'test2').matches('test', 'test2')).toBeTruthy();
+    });
+
+    it('should match equal multiple values out of order', () => {
+      expect(new Only('test', 'test2').matches('test2', 'test')).toBeTruthy();
+    });
+
+    it('should not match a single value against multiple values', () => {
+      expect(new Only('test').matches('test', 'test2')).toBeFalsy();
+    });
+  });
+});

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -1,6 +1,6 @@
 'use babel';
 
-import { zip, takeWhile } from '../lib/utils';
+import { zip, zipLongest, takeWhile } from '../lib/utils';
 
 
 describe('Utils', () => {
@@ -15,6 +15,20 @@ describe('Utils', () => {
 
     it('should zip no arrays', () => {
       expect(zip()).toEqual([]);
+    });
+  });
+
+  describe('zipLongest', () => {
+    it('should zip arrays', () => {
+      expect(zipLongest([1, 2], [3, 4])).toEqual([[1, 3], [2, 4]]);
+    });
+
+    it('should zip the longest arrays', () => {
+      expect(zipLongest([1, 2], [3])).toEqual([[1, 3], [2, undefined]]);
+    });
+
+    it('should zip no arrays', () => {
+      expect(zipLongest()).toEqual([]);
     });
   });
 


### PR DESCRIPTION
Allows you to use `only:` or `=` prefix to change matching behavior.

Examples:
=something
=something.else
=(something another)
only:something
only:something.else
only:(something another)

closes #5 
