### PR TITLE
Added not: modifier to the grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## master
 
 - Switched from PEGjs to Chevrotain parser
+- Added negation modifier
+ - !(scope1 scope2)
+ - not:scope1
+ = !scope1
 
 ## 0.5.1 - 2016-03-05
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -16,7 +16,7 @@ class Assertion {
   }
 
   message() {
-    return `${this.matcher.scopes.join(', ')} at ${this.line}:${this.column}`;
+    return `${this.matcher.message()} at ${this.line}:${this.column}`;
   }
 }
 

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -30,12 +30,24 @@ class Identifier extends Token {
 }
 class Modifier extends Token {
   static PATTERN = Lexer.NA;
+
+  code() {
+    throw Error('Must implement in sub-class');
+  }
 }
 class Only extends Modifier {
   static PATTERN = /only:|=/;
+
+  code() {
+    return '=';
+  }
 }
 class Not extends Modifier {
   static PATTERN = /not:|!/;
+
+  code() {
+    return '!';
+  }
 }
 class OpenParens extends Token {
   static PATTERN = /\(/;
@@ -73,6 +85,7 @@ export default function(openToken, closeToken = null) {
     EndLinePosition,
     OpenTokenPosition,
     CaratPosition,
+    Modifier,
     Only,
     Not,
     Identifier,
@@ -142,20 +155,10 @@ export default function(openToken, closeToken = null) {
       ]));
 
 
-      this.only = $.RULE('only', () => {
-        $.CONSUME(Only);
-        return '=';
+      this.modifier = $.RULE('modifier', () => {
+        const modifier = $.CONSUME(Modifier);
+        return modifier.code();
       });
-
-      this.not = $.RULE('not', () => {
-        $.CONSUME(Not);
-        return '!';
-      });
-
-      this.modifier = $.RULE('modifier', () => $.OR([
-        { ALT: () => $.SUBRULE($.only) },
-        { ALT: () => $.SUBRULE($.not) },
-      ]));
 
       this.scope = $.RULE('scope', () => {
         const idents = [];

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -34,6 +34,9 @@ class Modifier extends Token {
 class Only extends Modifier {
   static PATTERN = /only:|=/;
 }
+class Not extends Modifier {
+  static PATTERN = /not:|!/;
+}
 class OpenParens extends Token {
   static PATTERN = /\(/;
 }
@@ -71,6 +74,7 @@ export default function(openToken, closeToken = null) {
     OpenTokenPosition,
     CaratPosition,
     Only,
+    Not,
     Identifier,
     Period,
     OpenParens,
@@ -143,7 +147,15 @@ export default function(openToken, closeToken = null) {
         return '=';
       });
 
-      this.modifier = $.RULE('modifier', () => $.SUBRULE($.only));
+      this.not = $.RULE('not', () => {
+        $.CONSUME(Not);
+        return '!';
+      });
+
+      this.modifier = $.RULE('modifier', () => $.OR([
+        { ALT: () => $.SUBRULE($.only) },
+        { ALT: () => $.SUBRULE($.not) },
+      ]));
 
       this.scope = $.RULE('scope', () => {
         const idents = [];

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,12 +17,12 @@ const customMatchers = {
     const token = assertion.findToken(...this.actual);
 
     if (!token) {
-      this.message = () => `Expected to find ${assertion.message()}, instead found no token`;
+      this.message = () => `Expected ${assertion.message()}, instead found no token`;
       return false;
     }
 
     if (!assertion.matcher.matches(...token.scopes)) {
-      this.message = () => `Expected to find ${assertion.message()}, instead found ${token.scopes.join(', ')}`;
+      this.message = () => `Expected ${assertion.message()}, instead found ${token.scopes.join(', ')}`;
       return false;
     }
 

--- a/lib/matchers.js
+++ b/lib/matchers.js
@@ -29,7 +29,7 @@ export class Contains extends Matcher {
   }
 
   message() {
-    return this.scopes.join(', ');
+    return `to find ${this.scopes.join(', ')}`;
   }
 }
 
@@ -43,7 +43,18 @@ export class Only extends Matcher {
   }
 
   message() {
-    return `only ${this.scopes.join(', ')}`;
+    return `to find only ${this.scopes.join(', ')}`;
+  }
+}
+
+
+export class Not extends Contains {
+  matches(...scopes) {
+    return !super.matches(...scopes);
+  }
+
+  message() {
+    return `to not find ${this.scopes.join(', ')}`;
   }
 }
 
@@ -54,6 +65,8 @@ export function matcherBuilder(modifier, ...scopes) {
       return new Contains(...scopes);
     case '=':
       return new Only(...scopes);
+    case '!':
+      return new Not(...scopes);
     default:
       throw Error(`Unknown modifier: ${modifier}`);
   }

--- a/spec/assertions-spec.js
+++ b/spec/assertions-spec.js
@@ -1,6 +1,7 @@
 'use babel';
 
 import { AssertionParser } from '../lib/assertions';
+import { Not, Only } from '../lib/matchers';
 import { parsedLineFixture } from './utils';
 
 
@@ -206,6 +207,32 @@ describe('Assertions', () => {
         'some.symbol',
       ]);
       expect(assertion2.column).toEqual(10);
+    });
+
+    it('should parse only modifiers', () => {
+      const parser = parserFixture('// ', '',
+        '#pragma once',
+        '// ^ =something.else'
+      );
+
+      const assertion = Array.from(parser)[0].assertions[0];
+      expect(assertion.matcher instanceof Only).toBeTruthy();
+      expect(assertion.matcher.scopes).toEqual([
+        'something.else',
+      ]);
+    });
+
+    it('should parse not modifiers', () => {
+      const parser = parserFixture('// ', '',
+        '#pragma once',
+        '// ^ !something.else'
+      );
+
+      const assertion = Array.from(parser)[0].assertions[0];
+      expect(assertion.matcher instanceof Not).toBeTruthy();
+      expect(assertion.matcher.scopes).toEqual([
+        'something.else',
+      ]);
     });
   });
 });

--- a/spec/assertions-spec.js
+++ b/spec/assertions-spec.js
@@ -35,7 +35,7 @@ describe('Assertions', () => {
       const parser = parserFixture('<!-- ', ' -->',
         '<script> console.log("hi"); </script>',
         '<!-- << =text.html.basic -->',
-        '<!-- >> source.js.embedded.html -->',
+        '<!-- >> !source.js.embedded.html -->',
         '<!-- >> =text.html.basic -->',
       );
 

--- a/spec/fixtures/HTML/syntax_test_html_inline.html
+++ b/spec/fixtures/HTML/syntax_test_html_inline.html
@@ -2,4 +2,5 @@
 <script> console.log('hi'); </script>
 <!-- << =text.html.basic -->
 <!--    ^^^^^^^^^^^^^^^^^^^^ source.js.embedded.html -->
+<!-- >> !source.js.embedded.html -->
 <!-- >> =text.html.basic -->

--- a/spec/grammar-spec.js
+++ b/spec/grammar-spec.js
@@ -40,11 +40,13 @@ describe('Grammar', () => {
     itShouldLex('// <- something');
     itShouldLex('// <-        something');
     itShouldLex('// <- =something');
+    itShouldLex('// <- !something');
     itShouldLex('// <- only:something');
     itShouldLex('// <- only:something.else');
     itShouldLex('// <- only:something.else');
     itShouldLex('// <- only:(something.else another)');
     itShouldLex('// <- only:(something.else)');
+    itShouldLex('// <- not:(something.else)');
 
     itShouldNotLex('##');
     itShouldNotLex('<>');
@@ -150,6 +152,12 @@ describe('Grammar', () => {
       itShouldParse('// << only:(something)');
       itShouldParse('// << only:(something.else)');
       itShouldParse('// << only:(something another.else)');
+      itShouldParse('// << !(something)');
+      itShouldParse('// << !(something.else)');
+      itShouldParse('// << !(something another.else)');
+      itShouldParse('// << not:(something)');
+      itShouldParse('// << not:(something.else)');
+      itShouldParse('// << not:(something another.else)');
 
       itShouldNotParse('// << something.');
       itShouldNotParse('// << .something');
@@ -161,6 +169,12 @@ describe('Grammar', () => {
       itShouldNotParse('// << only:');
       itShouldNotParse('// << only:()');
       itShouldNotParse('// << only:something another');
+      itShouldNotParse('// << !');
+      itShouldNotParse('// << !()');
+      itShouldNotParse('// << !:something another');
+      itShouldNotParse('// << not:');
+      itShouldNotParse('// << not:()');
+      itShouldNotParse('// << not:something another');
 
       it('should parse a single scope', () => {
         expect(parse(lex('// << something'))).toEqual([
@@ -208,6 +222,34 @@ describe('Grammar', () => {
         expect(parse(lex('// << =(something another)'))).toEqual([
           [0],
           ['=', ['something', 'another']],
+        ]);
+      });
+
+      it('should parse a negated single scope', () => {
+        expect(parse(lex('// << !something'))).toEqual([
+          [0],
+          ['!', ['something']],
+        ]);
+      });
+
+      it('should parse a negated grouped single scope', () => {
+        expect(parse(lex('// << not:(something)'))).toEqual([
+          [0],
+          ['!', ['something']],
+        ]);
+      });
+
+      it('should parse a single negated nested scope', () => {
+        expect(parse(lex('// << !something.else'))).toEqual([
+          [0],
+          ['!', ['something.else']],
+        ]);
+      });
+
+      it('should parse negated multiple scopes', () => {
+        expect(parse(lex('// << !(something another)'))).toEqual([
+          [0],
+          ['!', ['something', 'another']],
         ]);
       });
     });

--- a/spec/matchers-spec.js
+++ b/spec/matchers-spec.js
@@ -1,6 +1,6 @@
 'use babel';
 
-import { Contains, Only } from '../lib/matchers';
+import { Contains, Only, Not } from '../lib/matchers';
 
 
 describe('Matchers', () => {
@@ -45,6 +45,28 @@ describe('Matchers', () => {
 
     it('should not match a single value against multiple values', () => {
       expect(new Only('test').matches('test', 'test2')).toBeFalsy();
+    });
+  });
+
+  describe('Not', () => {
+    it('should not match equal single value', () => {
+      expect(new Not('test').matches('test')).toBeFalsy();
+    });
+
+    it('should match a single value against multiple values', () => {
+      expect(new Not('test').matches('test', 'test2')).toBeFalsy();
+    });
+
+    it('should match a different value against a single value', () => {
+      expect(new Not('blah').matches('test')).toBeTruthy();
+    });
+
+    it('should match a different value against multiple values', () => {
+      expect(new Not('blah').matches('test', 'test2')).toBeTruthy();
+    });
+
+    it('should match multiple different value against multiple values', () => {
+      expect(new Not('blah', 'argh').matches('test', 'test2')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
```
// ^ !something.else
// << !(first second)
// >> not:(one two three)
```

Fixes #12.

@nixel2007 could you give this a try?
