### PR TITLE
Ignore whitespace in header line

### DIFF
--- a/docs/grammar.html
+++ b/docs/grammar.html
@@ -161,18 +161,25 @@ exports.default = function (openToken) {
       var _this16 = _possibleConstructorReturn(this, Object.getPrototypeOf(GrammarParser).call(this, input, allTokens, false /* isErrorRecoveryEnabled */));
 
       var $ = _this16;
-      var openTokenLength = openToken.length;
+      var openTokenPos = -1;
 
       _this16.root = $.RULE('assertion', function () {
         $.OPTION(function () {
           return $.CONSUME(Whitespace);
         });
-        $.CONSUME(Comment);
+        var commentToken = $.CONSUME(Comment);
+        openTokenPos = commentToken.startColumn;
+        $.OPTION2(function () {
+          return $.CONSUME2(Whitespace);
+        });
         var positions = $.SUBRULE($.positions);
-        $.CONSUME2(Whitespace);
+        $.CONSUME3(Whitespace);
         var scopes = $.SUBRULE($.rules);
+        $.OPTION3(function () {
+          return $.CONSUME4(Whitespace);
+        });
         // Need to force consuming EOF to capture an optional close token
-        $.CONSUME(_chevrotain.EOF);
+        $.CONSUME5(_chevrotain.EOF);
         return [positions, scopes];
       });
 
@@ -184,8 +191,8 @@ exports.default = function (openToken) {
             $.CONSUME(EndOfLine);
             return [-1];
           } }, { ALT: function ALT() {
-            var token = $.CONSUME(Beginning);
-            return [token.startColumn - openTokenLength];
+            $.CONSUME(Beginning);
+            return [openTokenPos];
           } }, { ALT: function ALT() {
             var positions = [];
             $.AT_LEAST_ONE(isCaratLookahead, function () {
@@ -209,7 +216,7 @@ exports.default = function (openToken) {
 
       _this16.scopes = $.RULE('scopes', function () {
         var scopes = [$.SUBRULE($.scope)];
-        $.MANY(function () {
+        $.MANY(isScopeLookahead, function () {
           $.CONSUME(Whitespace);
           var scope = $.SUBRULE2($.scope);
           scopes.push(scope);
@@ -483,6 +490,12 @@ CloseParens.LABEL = ')';
 
 function isCaratLookahead() {
   var result = this.LA(1) instanceof Carat || this.LA(1) instanceof Whitespace && this.LA(2) instanceof Carat;
+
+  return result;
+}
+
+function isScopeLookahead() {
+  var result = this.LA(1) instanceof Identifier || this.LA(1) instanceof Whitespace && this.LA(2) instanceof Identifier;
 
   return result;
 }
@@ -1566,7 +1579,7 @@ function isCaratLookahead() {
 );
 
 },{}],7:[function(require,module,exports){
-/*! chevrotain - v0.6.0 */
+/*! chevrotain - v0.6.2 */
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
 		module.exports = factory();
@@ -1636,10 +1649,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	 */
 	var API = {};
 	// semantic version
-	API.VERSION = "0.6.0";
+	API.VERSION = "0.6.2";
 	// runtime API
 	API.Parser = parser_public_1.Parser;
+	API.ParserDefinitionErrorType = parser_public_1.ParserDefinitionErrorType;
 	API.Lexer = lexer_public_1.Lexer;
+	API.LexerDefinitionErrorType = lexer_public_1.LexerDefinitionErrorType;
 	API.Token = tokens_public_1.Token;
 	API.VirtualToken = tokens_public_1.VirtualToken;
 	API.EOF = tokens_public_1.EOF;

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -64,6 +64,16 @@ function isCaratLookahead() {
   return result;
 }
 
+function isScopeLookahead() {
+  const result = (
+    this.LA(1) instanceof Identifier
+  ) || (
+    this.LA(1) instanceof Whitespace && this.LA(2) instanceof Identifier
+  );
+
+  return result;
+}
+
 
 export default function(openToken, closeToken = null) {
   class Comment extends Token {
@@ -97,16 +107,19 @@ export default function(openToken, closeToken = null) {
     constructor(input) {
       super(input, allTokens, false /* isErrorRecoveryEnabled */);
       const $ = this;
-      const openTokenLength = openToken.length;
+      let openTokenPos = -1;
 
       this.root = $.RULE('assertion', () => {
         $.OPTION(() => $.CONSUME(Whitespace));
-        $.CONSUME(Comment);
+        const commentToken = $.CONSUME(Comment);
+        openTokenPos = commentToken.startColumn;
+        $.OPTION2(() => $.CONSUME2(Whitespace));
         const positions = $.SUBRULE($.positions);
-        $.CONSUME2(Whitespace);
+        $.CONSUME3(Whitespace);
         const scopes = $.SUBRULE($.rules);
+        $.OPTION3(() => $.CONSUME4(Whitespace));
         // Need to force consuming EOF to capture an optional close token
-        $.CONSUME(EOF);
+        $.CONSUME5(EOF);
         return [positions, scopes];
       });
 
@@ -120,8 +133,8 @@ export default function(openToken, closeToken = null) {
           return [-1];
         } },
         { ALT: () => {
-          const token = $.CONSUME(Beginning);
-          return [token.startColumn - openTokenLength];
+          $.CONSUME(Beginning);
+          return [openTokenPos];
         } },
         { ALT: () => {
           const positions = [];
@@ -144,7 +157,7 @@ export default function(openToken, closeToken = null) {
 
       this.scopes = $.RULE('scopes', () => {
         const scopes = [$.SUBRULE($.scope)];
-        $.MANY(() => {
+        $.MANY(isScopeLookahead, () => {
           $.CONSUME(Whitespace);
           const scope = $.SUBRULE2($.scope);
           scopes.push(scope);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,7 @@
 'use babel';
 
 
-const HEADER_REGEX = /^(.+?)SYNTAX TEST (['"])([^\2]+)\2(.*)$/i;
+const HEADER_REGEX = /^(\S+?)\s+SYNTAX TEST\s+(['"])([^\2]+)\2\s*(\S*)$/i;
 
 
 class Header {

--- a/spec/grammar-spec.js
+++ b/spec/grammar-spec.js
@@ -3,7 +3,7 @@
 import parser from '../lib/grammar';
 import { escapeSpecName } from '../lib/jasmine';
 
-const { lex, parse } = parser('// ');
+const { lex, parse } = parser('//');
 
 
 function itShouldLex(expression) {
@@ -60,7 +60,7 @@ describe('Grammar', () => {
     });
 
     it('should could correctly lex custom open and closetokens', () => {
-      const { lex: hashLex } = parser('<!-- ', ' -->');
+      const { lex: hashLex } = parser('<!--', '-->');
       expect(() => hashLex('<!-- <- something -->')).not.toThrow();
     });
   });
@@ -68,19 +68,21 @@ describe('Grammar', () => {
   describe('Parsing', () => {
     describe('OpenToken', () => {
       itShouldParse('// << something');
+      itShouldParse('//<< something');
+      itShouldParse('//^ something');
       itShouldParse('   // << something');
       itShouldParse('   // << something');
 
       it('should could correctly parse custom open tokens', () => {
-        const { lex: htmlLex, parse: htmlParse } = parser('##########');
-        expect(htmlParse(htmlLex('##########<- something'))).toEqual([
+        const { lex: hashLex, parse: hashParse } = parser('##########');
+        expect(hashParse(hashLex('########## <- something'))).toEqual([
           [1],
           ['@', ['something']],
         ]);
       });
 
       it('should could correctly parse custom open and close tokens', () => {
-        const { lex: hashLex, parse: hashParse } = parser('<!-- ', ' -->');
+        const { lex: hashLex, parse: hashParse } = parser('<!--', '-->');
         expect(hashParse(hashLex('<!-- <- something -->'))).toEqual([
           [1],
           ['@', ['something']],

--- a/spec/parser-spec.js
+++ b/spec/parser-spec.js
@@ -33,9 +33,9 @@ describe('AtomGrammarTest Parser', () => {
     });
 
     it('should parse the comment token', () => {
-      expect(this.parser.header.openToken).toBe('// ');
-      expect(this.htmlParser.header.openToken).toBe('<!-- ');
-      expect(this.htmlParser.header.closeToken).toBe(' -->');
+      expect(this.parser.header.openToken).toBe('//');
+      expect(this.htmlParser.header.openToken).toBe('<!--');
+      expect(this.htmlParser.header.closeToken).toBe('-->');
     });
 
     it('should parse the source declaration', () => {


### PR DESCRIPTION
Ignore the whitespace in the syntax test header line and don't include
it in the open and close tokens to allow placing a carat immediately
after the opening comment.

Fixes #19
