### PR TITLE
Don't instantiate the grammar on every test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Master
+
+- Reduced memory by not reloading grammr on every test spec
+
 ## 0.6.1 - 2016-03-27
 
 - Separate whitespace from comment open and close tokens (`//^ something`)

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,10 +36,18 @@ export default function(filename) {
     const parser = parse(lines(filename));
     const grammarTest = new AssertionParser(parser);
     let lineAccumulator = [];
+    let grammar = null;
 
     beforeEach(function() { this.addMatchers(customMatchers); });
     beforeEach(function() {
-      this.grammar = atom.grammars.grammarForScopeName(grammarTest.header.scope);
+      // No need to re-instantiate the grammar for every test, just create it
+      // the first time within the spec
+      //
+      // This is basically a poor-man's beforeAll but Jasmine 1.3 doesn't support
+      // (though we want to this to run after other beforeEach's defined higher up)
+      if (!grammar) {
+        grammar = atom.grammars.grammarForScopeName(grammarTest.header.scope);
+      }
     });
 
     function addAssertions(grammarLines, rootScope) {
@@ -57,7 +65,7 @@ export default function(filename) {
 
         for (const line of grammarLines) {
           startRuleStack = endRuleStack;
-          const { tokens, ruleStack } = this.grammar.tokenizeLine(line.line, endRuleStack, endRuleStack === null);
+          const { tokens, ruleStack } = grammar.tokenizeLine(line.line, endRuleStack, endRuleStack === null);
 
           lastTokens = tokens;
           endRuleStack = ruleStack;


### PR DESCRIPTION
This seems to lock the RSS to a max of ~300MB compared to growing to the GBs when re-instantiating the grammar on every case.

Fixes #21
