### PR TITLE
Fixed lack of escape on open and close token regex for grammar

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -3,6 +3,7 @@
 /* eslint-disable new-cap */
 
 import { Lexer, Parser, Token, EOF } from 'chevrotain';
+import escapeStringRegexp from 'escape-string-regexp';
 
 
 class Whitespace extends Token {
@@ -78,11 +79,11 @@ function isScopeLookahead() {
 
 export default function(openToken, closeToken = null) {
   class Comment extends Token {
-    static PATTERN = new RegExp(openToken);
+    static PATTERN = new RegExp(escapeStringRegexp(openToken));
   }
 
   class EndComment extends EOF {
-    static PATTERN = closeToken ? new RegExp(closeToken) : Lexer.NA;
+    static PATTERN = closeToken ? new RegExp(escapeStringRegexp(closeToken)) : Lexer.NA;
   }
 
   const allTokens = [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "chevrotain": "./node_modules/chevrotain/lib/chevrotain"
   },
   "dependencies": {
-    "chevrotain": "^0.18.0"
+    "chevrotain": "^0.18.0",
+    "escape-string-regexp": "^1.0.5"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/spec/fixtures/C/syntax_test_c_example2.c
+++ b/spec/fixtures/C/syntax_test_c_example2.c
@@ -1,0 +1,24 @@
+/* SYNTAX TEST "source.c" */
+#pragma once
+/* <- punctuation.definition.directive meta.preprocessor */
+ /* <- keyword.control.directive.pragma */
+
+#include "stdio.h"
+/* <- keyword.control.directive.include */
+/*       ^ meta string punctuation.definition.string.begin */
+/*               ^ meta string punctuation.definition.string.end */
+int square(int x)
+/* <- storage.type */
+/*  ^ meta.function entity.name.function */
+/*         ^ storage.type */
+{
+    return x * x;
+/*  ^^^^^^ keyword.control */
+}
+
+"Hello, World! not a comment";
+/* ^ string.quoted.double */
+/*                  ^ string.quoted.double */
+
+/* EOF Check (root scope) */
+/* >> source.c */

--- a/spec/grammar-spec.js
+++ b/spec/grammar-spec.js
@@ -63,6 +63,10 @@ describe('Grammar', () => {
       const { lex: hashLex } = parser('<!--', '-->');
       expect(() => hashLex('<!-- <- something -->')).not.toThrow();
     });
+    it('should could correctly lex custom open and closetokens with regex special characters', () => {
+      const { lex: hashLex } = parser('/*', '*/');
+      expect(() => hashLex('/* <- something */')).not.toThrow();
+    });
   });
 
   describe('Parsing', () => {

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -11,6 +11,7 @@ describe('Atom Grammar Test Jasmine', () => {
   describe('C Syntax Assertions', () => {
     beforeEach(() => waitsForPromise(() => atom.packages.activatePackage('language-c')));
     grammarTest(fixtureFilename('C/syntax_test_c_example.c'));
+    grammarTest(fixtureFilename('C/syntax_test_c_example2.c'));
   });
   describe('HTML Syntax Assertions', () => {
     beforeEach(() => waitsForPromise(() => atom.packages.activatePackage('language-html')));


### PR DESCRIPTION
Resolves #28