### PR TITLE
Fixed syntax tweaks to C in Atom 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
-
+language: javascript
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
-language: javascript
+language: node_js
 os:
   - linux
   - osx

--- a/spec/fixtures/C/syntax_test_c_example.c
+++ b/spec/fixtures/C/syntax_test_c_example.c
@@ -1,6 +1,6 @@
 // SYNTAX TEST "source.c"
 #pragma once
-// <- punctuation.definition.directive meta.preprocessor.c
+// <- punctuation.definition.directive meta.preprocessor
  // <- keyword.control.directive.pragma
 
 // foo

--- a/spec/parser-spec.js
+++ b/spec/parser-spec.js
@@ -6,50 +6,53 @@ import { lineFixture } from './utils';
 
 describe('AtomGrammarTest Parser', () => {
   describe('Header', () => {
+    const filename = 'blah.txt';
+    let parser;
+    let htmlParser;
+
     beforeEach(() => {
-      this.filename = 'blah.txt';
-      this.iterator = lineFixture(this.filename,
+      const iterator = lineFixture(filename,
         '// SYNTAX TEST "source.c"',
         '#pragma once',
         '// <- punctuation.definition.directive meta.preprocessor.c',
         ' // <- keyword.control.directive.pragma',
       );
-      this.parser = parse(this.iterator);
+      parser = parse(iterator);
     });
 
     beforeEach(() => {
-      this.htmlFilename = 'something.html';
-      this.htmlIterator = lineFixture(this.htmlFilename,
+      const htmlFilename = 'something.html';
+      const htmlIterator = lineFixture(htmlFilename,
         '<!-- SYNTAX TEST "text.html.basic" -->',
         '<TagName>',
         '<!-- <- punctuation.definition.tag.begin.html -->',
         '<!-- ^ entity.name.tag.other.html -->',
       );
-      this.htmlParser = parse(this.htmlIterator);
+      htmlParser = parse(htmlIterator);
     });
 
     it('should remember the filename', () => {
-      expect(this.parser.filename).toBe(this.filename);
+      expect(parser.filename).toBe(filename);
     });
 
     it('should parse the comment token', () => {
-      expect(this.parser.header.openToken).toBe('//');
-      expect(this.htmlParser.header.openToken).toBe('<!--');
-      expect(this.htmlParser.header.closeToken).toBe('-->');
+      expect(parser.header.openToken).toBe('//');
+      expect(htmlParser.header.openToken).toBe('<!--');
+      expect(htmlParser.header.closeToken).toBe('-->');
     });
 
     it('should parse the source declaration', () => {
-      expect(this.parser.header.scope).toBe('source.c');
-      expect(this.htmlParser.header.scope).toBe('text.html.basic');
+      expect(parser.header.scope).toBe('source.c');
+      expect(htmlParser.header.scope).toBe('text.html.basic');
     });
 
     it('should iterate the input lines', () => {
-      expect(Array.from(this.parser).map(line => line.line)).toEqual([
+      expect(Array.from(parser).map(line => line.line)).toEqual([
         '#pragma once',
         '// <- punctuation.definition.directive meta.preprocessor.c',
         ' // <- keyword.control.directive.pragma',
       ]);
-      expect(Array.from(this.htmlParser).map(line => line.line)).toEqual([
+      expect(Array.from(htmlParser).map(line => line.line)).toEqual([
         '<TagName>',
         '<!-- <- punctuation.definition.tag.begin.html -->',
         '<!-- ^ entity.name.tag.other.html -->',


### PR DESCRIPTION
Atom 1.6 has changed some syntax classes that is causing test failures.  Update the syntax test to match.